### PR TITLE
Fix router import in login page

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -12,7 +12,7 @@ import {
   Tab,
   Tabs,
 } from '@mui/material'
-import router from 'next/router'
+import { useRouter } from 'next/navigation'
 
 interface TabPanelProps {
   children?: React.ReactNode
@@ -43,6 +43,7 @@ export default function AuthPage() {
   const [confirmPassword, setConfirmPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
+  const router = useRouter()
 
 
   // Verificar se já está autenticado


### PR DESCRIPTION
## Summary
- fix incorrect router usage in login page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864403d2800832fba607c33fc46f8de