### PR TITLE
Add admin report detail view

### DIFF
--- a/src/app/relatorios-alunos/[id]/page.tsx
+++ b/src/app/relatorios-alunos/[id]/page.tsx
@@ -17,7 +17,9 @@ import {
   TableRow,
   Button,
   Alert,
-  Chip
+  Chip,
+  Dialog,
+  DialogContent
 } from '@mui/material'
 import { ArrowBack } from '@mui/icons-material'
 
@@ -26,6 +28,7 @@ interface Relatorio {
   data_relatorio: string
   conteudo: string
   dia_semana: string
+  img_url?: string | null
 }
 
 export default function RelatoriosAlunoDetalhe() {
@@ -37,6 +40,7 @@ export default function RelatoriosAlunoDetalhe() {
   const [error, setError] = useState<string | null>(null)
   const [alunoNome, setAlunoNome] = useState<string>('')
   const [relatorios, setRelatorios] = useState<Relatorio[]>([])
+  const [imagemSelecionada, setImagemSelecionada] = useState<string | null>(null)
 
   useEffect(() => {
     const carregar = async () => {
@@ -73,7 +77,7 @@ export default function RelatoriosAlunoDetalhe() {
 
         const { data, error } = await supabase
           .from('relatorios')
-          .select('*')
+          .select('id, data_relatorio, conteudo, dia_semana, img_url')
           .eq('id_aluno', alunoId)
           .order('data_relatorio', { ascending: false })
 
@@ -138,22 +142,51 @@ export default function RelatoriosAlunoDetalhe() {
                 <TableCell>Data do Relatório</TableCell>
                 <TableCell>Dia da Semana</TableCell>
                 <TableCell>Conteúdo</TableCell>
+                <TableCell>Foto</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
               {relatorios.map((relatorio) => (
-                <TableRow key={relatorio.id}>
+                <TableRow
+                  key={relatorio.id}
+                  hover
+                  sx={{ cursor: relatorio.img_url ? 'pointer' : 'default' }}
+                  onClick={() => relatorio.img_url && setImagemSelecionada(relatorio.img_url)}
+                >
                   <TableCell>{formatarData(relatorio.data_relatorio)}</TableCell>
                   <TableCell>
                     <Chip label={relatorio.dia_semana} color='primary' variant='outlined' size='small' />
                   </TableCell>
                   <TableCell sx={{ whiteSpace: 'pre-wrap' }}>{relatorio.conteudo}</TableCell>
+                  <TableCell>
+                    {relatorio.img_url && (
+                      <Box
+                        component='img'
+                        src={relatorio.img_url}
+                        alt='Miniatura do relatório'
+                        sx={{ width: 60, height: 60, objectFit: 'cover', borderRadius: 1 }}
+                      />
+                    )}
+                  </TableCell>
                 </TableRow>
               ))}
             </TableBody>
           </Table>
         </TableContainer>
       )}
+
+      <Dialog open={Boolean(imagemSelecionada)} onClose={() => setImagemSelecionada(null)} maxWidth='lg'>
+        <DialogContent>
+          {imagemSelecionada && (
+            <Box
+              component='img'
+              src={imagemSelecionada}
+              alt='Foto do relatório'
+              sx={{ width: '100%', height: 'auto', maxWidth: 600 }}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
     </Container>
   )
 }

--- a/src/app/relatorios-alunos/[id]/page.tsx
+++ b/src/app/relatorios-alunos/[id]/page.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter, useParams } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+import {
+  Container,
+  Box,
+  Typography,
+  Paper,
+  CircularProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Button,
+  Alert,
+  Chip
+} from '@mui/material'
+import { ArrowBack } from '@mui/icons-material'
+
+interface Relatorio {
+  id: number
+  data_relatorio: string
+  conteudo: string
+  dia_semana: string
+}
+
+export default function RelatoriosAlunoDetalhe() {
+  const router = useRouter()
+  const params = useParams()
+  const alunoId = params.id as string | undefined
+
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [alunoNome, setAlunoNome] = useState<string>('')
+  const [relatorios, setRelatorios] = useState<Relatorio[]>([])
+
+  useEffect(() => {
+    const carregar = async () => {
+      try {
+        const { data: { session } } = await supabase.auth.getSession()
+        if (!session?.user) {
+          router.push('/login')
+          return
+        }
+
+        const { data: profile } = await supabase
+          .from('profiles')
+          .select('tipo_usuario')
+          .eq('id', session.user.id)
+          .single()
+
+        if (profile?.tipo_usuario !== 'admin') {
+          router.push('/')
+          return
+        }
+
+        if (!alunoId) {
+          setError('Aluno não encontrado')
+          return
+        }
+
+        const { data: aluno } = await supabase
+          .from('profiles')
+          .select('nome_completo')
+          .eq('id', alunoId)
+          .single()
+
+        setAlunoNome(aluno?.nome_completo || '')
+
+        const { data, error } = await supabase
+          .from('relatorios')
+          .select('*')
+          .eq('id_aluno', alunoId)
+          .order('data_relatorio', { ascending: false })
+
+        if (error) throw error
+
+        setRelatorios(data || [])
+      } catch (err) {
+        console.error('Erro ao carregar relatórios:', err)
+        setError('Não foi possível carregar os relatórios')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    carregar()
+  }, [router, alunoId])
+
+  const formatarData = (data: string) => {
+    return new Date(data).toLocaleDateString('pt-BR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    })
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '80vh' }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  return (
+    <Container maxWidth='lg' sx={{ py: 4 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 4 }}>
+        <Button startIcon={<ArrowBack />} onClick={() => router.push('/relatorios-alunos')} variant='outlined'>
+          Voltar
+        </Button>
+        <Typography variant='h4' component='h1'>
+          Relatórios de {alunoNome}
+        </Typography>
+      </Box>
+
+      {error && (
+        <Alert severity='error' sx={{ mb: 4 }}>
+          {error}
+        </Alert>
+      )}
+
+      {relatorios.length === 0 ? (
+        <Paper sx={{ p: 4, textAlign: 'center' }}>
+          <Typography variant='h6' color='text.secondary'>Nenhum relatório encontrado</Typography>
+        </Paper>
+      ) : (
+        <TableContainer component={Paper}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Data do Relatório</TableCell>
+                <TableCell>Dia da Semana</TableCell>
+                <TableCell>Conteúdo</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {relatorios.map((relatorio) => (
+                <TableRow key={relatorio.id}>
+                  <TableCell>{formatarData(relatorio.data_relatorio)}</TableCell>
+                  <TableCell>
+                    <Chip label={relatorio.dia_semana} color='primary' variant='outlined' size='small' />
+                  </TableCell>
+                  <TableCell sx={{ whiteSpace: 'pre-wrap' }}>{relatorio.conteudo}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Container>
+  )
+}
+

--- a/src/app/relatorios-alunos/page.tsx
+++ b/src/app/relatorios-alunos/page.tsx
@@ -95,7 +95,12 @@ export default function RelatoriosAlunosPage() {
           </TableHead>
           <TableBody>
             {alunos.map(aluno => (
-              <TableRow key={aluno.id}>
+              <TableRow
+                key={aluno.id}
+                hover
+                sx={{ cursor: 'pointer' }}
+                onClick={() => router.push(`/relatorios-alunos/${aluno.id}`)}
+              >
                 <TableCell>{aluno.nome}</TableCell>
                 <TableCell align='right'>{aluno.quantidade}</TableCell>
               </TableRow>


### PR DESCRIPTION
## Summary
- make rows on `relatorios-alunos` clickable
- add a dynamic page to list all reports for a selected student

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644a544bb8832f8520ca69ebc8649d