### PR TITLE
Add multiple image support

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,7 +18,7 @@ interface Relatorio {
   data_relatorio: string
   conteudo: string
   dia_semana: string
-  img_url?: string | null
+  img_urls?: string[]
 }
 
 export default function HomePage() {
@@ -64,7 +64,11 @@ export default function HomePage() {
           .order('data_relatorio', { ascending: false })
           .limit(3)
 
-        setRelatorios(data || [])
+        const parsed = (data || []).map((r) => ({
+          ...r,
+          img_urls: r.img_url ? (JSON.parse(r.img_url) as string[]) : [],
+        }))
+        setRelatorios(parsed)
       }
     }
 
@@ -180,10 +184,10 @@ export default function HomePage() {
                 <Typography variant='subtitle2' color='text.secondary'>
                   {new Date(rel.data_relatorio).toLocaleDateString('pt-BR')} - {rel.dia_semana}
                 </Typography>
-                {rel.img_url && (
+                {rel.img_urls && rel.img_urls[0] && (
                   <Box
                     component='img'
-                    src={rel.img_url}
+                    src={rel.img_urls[0]}
                     alt='Imagem do relatório'
                     sx={{ width: '100%', maxHeight: 300, objectFit: 'cover', borderRadius: 1, mt: 1 }}
                   />

--- a/src/app/relatorio-diario/page.tsx
+++ b/src/app/relatorio-diario/page.tsx
@@ -27,7 +27,7 @@ interface Relatorio {
   data_relatorio?: string;
   conteudo: string;
   dia_semana: string;
-  img_url?: string;
+  img_urls?: string[];
 }
 
 const diasSemana = ['Segunda', 'Terça', 'Quarta', 'Quinta', 'Sexta'];
@@ -42,6 +42,7 @@ export default function RelatorioDiarioPage() {
     id_aluno: '',
     conteudo: '',
     dia_semana: '',
+    img_urls: [],
   });
 
   const uploadRef = useRef<UploadFotoHandle>(null);
@@ -83,12 +84,12 @@ export default function RelatorioDiarioPage() {
     setSuccess(null);
 
     try {
-      const fotoUrl = await uploadRef.current?.upload();
+      const fotoUrls = await uploadRef.current?.upload();
 
       const { error } = await supabase.from('relatorios').insert([
         {
           ...relatorio,
-          img_url: fotoUrl || null,
+          img_url: fotoUrls && fotoUrls.length > 0 ? JSON.stringify(fotoUrls) : null,
           data_relatorio: new Date().toISOString(),
         },
       ]);
@@ -100,7 +101,7 @@ export default function RelatorioDiarioPage() {
         ...relatorio,
         conteudo: '',
         dia_semana: '',
-        img_url: fotoUrl || undefined,
+        img_urls: fotoUrls || [],
       });
     } catch (err) {
       console.error('Erro ao salvar relatório:', err);
@@ -211,24 +212,28 @@ export default function RelatorioDiarioPage() {
               relatorioId={relatorio.id || Date.now()}
             />
 
-            {relatorio.img_url && (
+            {relatorio.img_urls && relatorio.img_urls.length > 0 && (
               <Box sx={{ mt: 3 }}>
                 <Typography variant="subtitle1" gutterBottom>
-                  Foto enviada com sucesso!
+                  Fotos enviadas com sucesso!
                 </Typography>
-                <Box
-                  component="img"
-                  src={relatorio.img_url}
-                  alt="Foto do relatório"
-                  sx={{
-                    width: '100%',
-                    maxWidth: 400,
-                    height: 'auto',
-                    objectFit: 'cover',
-                    borderRadius: 1,
-                    border: '1px solid #ddd',
-                  }}
-                />
+                <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+                  {relatorio.img_urls.map((url, index) => (
+                    <Box
+                      key={index}
+                      component="img"
+                      src={url}
+                      alt={`Foto ${index + 1}`}
+                      sx={{
+                        width: 120,
+                        height: 120,
+                        objectFit: 'cover',
+                        borderRadius: 1,
+                        border: '1px solid #ddd',
+                      }}
+                    />
+                  ))}
+                </Box>
               </Box>
             )}
           </Box>

--- a/src/app/relatorios-alunos/[id]/page.tsx
+++ b/src/app/relatorios-alunos/[id]/page.tsx
@@ -28,7 +28,7 @@ interface Relatorio {
   data_relatorio: string
   conteudo: string
   dia_semana: string
-  img_url?: string | null
+  img_urls?: string[]
 }
 
 export default function RelatoriosAlunoDetalhe() {
@@ -83,7 +83,11 @@ export default function RelatoriosAlunoDetalhe() {
 
         if (error) throw error
 
-        setRelatorios(data || [])
+        const parsed = (data || []).map((r) => ({
+          ...r,
+          img_urls: r.img_url ? (JSON.parse(r.img_url) as string[]) : [],
+        }))
+        setRelatorios(parsed)
       } catch (err) {
         console.error('Erro ao carregar relatórios:', err)
         setError('Não foi possível carregar os relatórios')
@@ -150,8 +154,11 @@ export default function RelatoriosAlunoDetalhe() {
                 <TableRow
                   key={relatorio.id}
                   hover
-                  sx={{ cursor: relatorio.img_url ? 'pointer' : 'default' }}
-                  onClick={() => relatorio.img_url && setImagemSelecionada(relatorio.img_url)}
+                  sx={{ cursor: relatorio.img_urls && relatorio.img_urls.length > 0 ? 'pointer' : 'default' }}
+                  onClick={() =>
+                    relatorio.img_urls && relatorio.img_urls.length > 0 &&
+                    setImagemSelecionada(relatorio.img_urls[0])
+                  }
                 >
                   <TableCell>{formatarData(relatorio.data_relatorio)}</TableCell>
                   <TableCell>
@@ -159,10 +166,10 @@ export default function RelatoriosAlunoDetalhe() {
                   </TableCell>
                   <TableCell sx={{ whiteSpace: 'pre-wrap' }}>{relatorio.conteudo}</TableCell>
                   <TableCell>
-                    {relatorio.img_url && (
+                    {relatorio.img_urls && relatorio.img_urls[0] && (
                       <Box
                         component='img'
-                        src={relatorio.img_url}
+                        src={relatorio.img_urls[0]}
                         alt='Miniatura do relatório'
                         sx={{ width: 60, height: 60, objectFit: 'cover', borderRadius: 1 }}
                       />


### PR DESCRIPTION
## Summary
- enable multiple photo uploads
- store JSON list of photo URLs in `img_url`
- preview uploaded photos and show the first photo in listings

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68649d5788f4832fb61df268627b50fa