### PR TITLE
Apply comic inspired theme

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,8 @@
 :root {
-  --background: #ffffff;
+  --background: #fafafa;
   --foreground: #171717;
+  --primary: #ff1744;
+  --secondary: #2979ff;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -19,9 +21,41 @@ body {
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-inter), sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  animation: pageFade 0.5s ease-in;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-bangers);
+  letter-spacing: 1px;
+}
+
+.MuiButton-root:active {
+  transform: scale(0.96);
+}
+
+.comic-card {
+  transition: transform 0.3s, box-shadow 0.3s;
+}
+
+.comic-card:hover {
+  transform: translateY(-5px) scale(1.05);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+}
+
+.MuiButton-containedPrimary {
+  background-color: var(--primary);
+}
+
+.MuiButton-containedSecondary {
+  background-color: var(--secondary);
+}
+
+@keyframes pageFade {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 * {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Inter } from "next/font/google";
+import { Inter, Bangers } from "next/font/google";
 import "./globals.css";
 import { Providers } from './providers'
 import Header from "./components/Header";
@@ -9,6 +9,12 @@ import { usePathname } from "next/navigation";
 const inter = Inter({
   subsets: ["latin"],
   variable: "--font-inter",
+});
+
+const bangers = Bangers({
+  subsets: ["latin"],
+  weight: "400",
+  variable: "--font-bangers",
 });
 
 export default function RootLayout({
@@ -20,7 +26,7 @@ export default function RootLayout({
 
   return (
     <html lang="pt-BR" suppressHydrationWarning>
-      <body className={inter.variable}>
+      <body className={`${inter.variable} ${bangers.variable}`}>
         <Providers>
           {pathname !== '/login' && <Header />}
           {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -154,6 +154,7 @@ export default function HomePage() {
             (!item.admin || isAdmin) && (!item.aluno || tipoUsuario === 'aluno') && (
               <Grid item xs={6} sm={6} key={item.title}>
                 <Paper
+                  className="comic-card"
                   sx={{
                     p: 3,
                     height: '100%',
@@ -162,11 +163,6 @@ export default function HomePage() {
                     alignItems: 'center',
                     textAlign: 'center',
                     cursor: 'pointer',
-                    transition: 'transform 0.2s, box-shadow 0.2s',
-                    '&:hover': {
-                      transform: 'translateY(-4px)',
-                      boxShadow: 4,
-                    },
                   }}
                   onClick={() => router.push(item.path)}
                 >
@@ -193,7 +189,7 @@ export default function HomePage() {
               Meus Últimos Relatórios
             </Typography>
             {relatorios.map((rel) => (
-              <Paper key={rel.id} sx={{ p: 2, mb: 2 }}>
+              <Paper key={rel.id} sx={{ p: 2, mb: 2 }} className="comic-card">
                 <Typography variant='subtitle2' color='text.secondary'>
                   {new Date(rel.data_relatorio).toLocaleDateString('pt-BR')} - {rel.dia_semana}
                 </Typography>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -9,10 +9,25 @@ const theme = createTheme({
   palette: {
     mode: 'light',
     primary: {
-      main: '#1976d2',
+      main: '#ff1744',
     },
     secondary: {
-      main: '#dc004e',
+      main: '#2979ff',
+    },
+  },
+  typography: {
+    fontFamily: 'var(--font-inter), sans-serif',
+    h1: {
+      fontFamily: 'var(--font-bangers)',
+      letterSpacing: 1,
+    },
+    h2: {
+      fontFamily: 'var(--font-bangers)',
+      letterSpacing: 1,
+    },
+    h3: {
+      fontFamily: 'var(--font-bangers)',
+      letterSpacing: 1,
     },
   },
 })


### PR DESCRIPTION
## Summary
- import Bangers font and use custom comic palette
- animate buttons and cards
- add global fade-in animation
- apply comic styles to home page cards

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669cd3ee20832f8fba0bb29b838db2