### PR TITLE
Fix student profile menu link

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -121,13 +121,6 @@ export default function HomePage() {
       icon: <Person sx={{ fontSize: 40 }} />,
       path: tipoUsuario === 'aluno' ? '/perfil-aluno' : '/perfil',
     },
-    {
-      title: 'Perfil Aluno',
-      description: 'Complete seus dados de aluno',
-      icon: <Person sx={{ fontSize: 40 }} />,
-      path: '/perfil-aluno',
-      aluno: true,
-    },
   ]
 
   return (


### PR DESCRIPTION
## Summary
- adjust home page menu so students use `/perfil-aluno` for the Perfil link

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68672a41d5c4832f85cdd6b2fa52147c