### PR TITLE
Improve mobile layout on schedule page

### DIFF
--- a/src/app/agendamento/page.tsx
+++ b/src/app/agendamento/page.tsx
@@ -71,6 +71,15 @@ export default function AgendamentoReforco() {
     [dia: string]: HorarioDisponivel[];
   }>({});
   const [diasDisponiveis, setDiasDisponiveis] = useState<string[]>([]);
+  const diasSemanaOrdenados = [
+    "Segunda",
+    "Terça",
+    "Quarta",
+    "Quinta",
+    "Sexta",
+    "Sábado",
+    "Domingo",
+  ];
   const [horariosUnicos, setHorariosUnicos] = useState<HorarioDisponivel[]>([]);
   useEffect(() => {
     const carregarUsuario = async () => {
@@ -150,7 +159,8 @@ export default function AgendamentoReforco() {
     });
 
     setHorariosPorDia(mapa);
-    setDiasDisponiveis(Object.keys(mapa));
+    const ordenados = diasSemanaOrdenados.filter((dia) => mapa[dia]);
+    setDiasDisponiveis(ordenados);
     setHorariosUnicos(Object.values(unicos));
   };
 
@@ -410,7 +420,12 @@ export default function AgendamentoReforco() {
             <Typography variant="subtitle1" gutterBottom>
               Dias da Semana (selecione até 3)
             </Typography>
-            <Box display="flex" gap={1} flexWrap="wrap">
+            <Box
+              display="flex"
+              gap={1}
+              flexWrap="wrap"
+              sx={{ justifyContent: { xs: "center", md: "flex-start" } }}
+            >
               {diasDisponiveis.map((dia) => (
                 <Button
                   key={dia}

--- a/src/app/agendamento/page.tsx
+++ b/src/app/agendamento/page.tsx
@@ -40,6 +40,16 @@ const diaNome = [
   "Sábado",
 ];
 
+const diaAbreviado: Record<string, string> = {
+  Segunda: "Seg",
+  Terça: "Ter",
+  Quarta: "Qua",
+  Quinta: "Qui",
+  Sexta: "Sex",
+  Sábado: "Sáb",
+  Domingo: "Dom",
+};
+
 type HorarioDisponivel = {
   text: string;
   value: string;
@@ -433,7 +443,7 @@ export default function AgendamentoReforco() {
                   onClick={() => toggleDia(dia)}
                   sx={{ flex: 1 }}
                 >
-                  {dia}
+                  {diaAbreviado[dia] || dia}
                 </Button>
               ))}
             </Box>


### PR DESCRIPTION
## Summary
- make schedule buttons wrap in a centered flex container for mobile
- ensure days of week are ordered correctly (Segunda–Sexta)

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68673022ea48832fac90db51314450dc