### PR TITLE
Enforce profile completion for students

### DIFF
--- a/src/app/agendamento/page.tsx
+++ b/src/app/agendamento/page.tsx
@@ -103,6 +103,17 @@ export default function AgendamentoReforco() {
           return;
         }
 
+        const { data: aluno, error: alunoError } = await supabase
+          .from('aluno')
+          .select('nome, data_nascimento')
+          .eq('id', session.user.id)
+          .single();
+
+        if (alunoError || !aluno?.nome || !aluno?.data_nascimento) {
+          router.push('/perfil-aluno');
+          return;
+        }
+
         const { data: profileData, error: profileError } = await supabase
           .from("profiles")
           .select("nome_completo, tipo_usuario, email")

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -132,8 +132,8 @@ export default function AuthPage() {
         // Força uma atualização do estado da sessão
         await supabase.auth.refreshSession()
 
-        // Obtém o tipo de usuário para definir o redirecionamento
-        const { data: perfil } = await supabase
+        // Garante que o perfil esteja atualizado antes do redirecionamento
+        await supabase
           .from('profiles')
           .select('tipo_usuario')
           .eq('id', authData.user.id)

--- a/src/app/relatorio-diario/page.tsx
+++ b/src/app/relatorio-diario/page.tsx
@@ -87,6 +87,17 @@ export default function RelatorioDiarioPage() {
           return;
         }
 
+        const { data: aluno, error: alunoError } = await supabase
+          .from('aluno')
+          .select('nome, data_nascimento')
+          .eq('id', session.user.id)
+          .single();
+
+        if (alunoError || !aluno?.nome || !aluno?.data_nascimento) {
+          router.push('/perfil-aluno');
+          return;
+        }
+
         setRelatorio((prev) => ({
           ...prev,
           id_aluno: session.user.id,


### PR DESCRIPTION
## Summary
- check student profile on scheduling and report pages
- keep login page clean for lint

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6867439c7630832fb10e1f0b59cebe08