### PR TITLE
Allow admin to submit daily report for students

### DIFF
--- a/src/app/relatorio-diario/page.tsx
+++ b/src/app/relatorio-diario/page.tsx
@@ -118,7 +118,12 @@ export default function RelatorioDiarioPage() {
             .select('id, nome_completo')
             .eq('tipo_usuario', 'aluno')
             .order('nome_completo');
-          setAlunos(alunosData || []);
+          setAlunos(
+            alunosData?.map(({ id, nome_completo }) => ({
+              id,
+              nome: nome_completo,
+            })) || []
+          );
         } else {
           setRelatorio((prev) => ({
             ...prev,

--- a/supabase/migrations/20240321000005_admin_insert_relatorios.sql
+++ b/supabase/migrations/20240321000005_admin_insert_relatorios.sql
@@ -1,0 +1,11 @@
+-- Allow admins to create reports for any student
+create policy "Admins podem criar relatorios para qualquer aluno"
+  on relatorios for insert
+  with check (
+    exists (
+      select 1
+      from profiles
+      where profiles.id = auth.uid()
+      and profiles.tipo_usuario = 'admin'
+    )
+  );


### PR DESCRIPTION
## Summary
- enable admins to pick a student when creating a daily report
- add migration allowing admins to insert reports for any student

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6878439823b0832f99cf9ee3a5238b19